### PR TITLE
Update status of magic-nix-cache-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,6 @@ These distances affect the restore and save speed.
 
 **Cons**:
 
-- Works only on GitHub Enterprise Server as of Feb 19, 2025 ([link](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/)).
 - Collects telemetry ([link](https://github.com/DeterminateSystems/magic-nix-cache#telemetry))
 - May trigger rate limit errors ([link](https://github.com/DeterminateSystems/magic-nix-cache#usage-notes)).
 - Follows the GitHub Actions Cache semantics ([link](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)).


### PR DESCRIPTION
Due to some recent changes, the [status of `magic-nix-cache-action`](https://determinate.systems/posts/bringing-back-magic-nix-cache-action/) can be updated in the README.