### PR TITLE
Use `macos-15-intel` runners instead of `macos-14`

### DIFF
--- a/.github/workflows/buildjet-ci.yaml
+++ b/.github/workflows/buildjet-ci.yaml
@@ -466,6 +466,10 @@ jobs:
         nix-installer:
           - DeterminateSystems/determinate-nix-action
           - nixbuild/nix-quick-install-action
+        exclude:
+          # See https://github.com/DeterminateSystems/nix-src/issues/224
+          - nix-installer: DeterminateSystems/determinate-nix-action
+            os: macos-15-intel
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout this repo
@@ -537,6 +541,10 @@ jobs:
         nix-installer:
           - DeterminateSystems/determinate-nix-action
           - nixbuild/nix-quick-install-action
+        exclude:
+          # See https://github.com/DeterminateSystems/nix-src/issues/224
+          - nix-installer: DeterminateSystems/determinate-nix-action
+            os: macos-15-intel
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout this repo

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -465,6 +465,10 @@ jobs:
         nix-installer:
           - DeterminateSystems/determinate-nix-action
           - nixbuild/nix-quick-install-action
+        exclude:
+          # See https://github.com/DeterminateSystems/nix-src/issues/224
+          - nix-installer: DeterminateSystems/determinate-nix-action
+            os: macos-15-intel
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout this repo
@@ -536,6 +540,10 @@ jobs:
         nix-installer:
           - DeterminateSystems/determinate-nix-action
           - nixbuild/nix-quick-install-action
+        exclude:
+          # See https://github.com/DeterminateSystems/nix-src/issues/224
+          - nix-installer: DeterminateSystems/determinate-nix-action
+            os: macos-15-intel
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout this repo

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -451,6 +451,10 @@ in
           nix-installer:
             - DeterminateSystems/determinate-nix-action
             - nixbuild/nix-quick-install-action
+          exclude:
+            # See https://github.com/DeterminateSystems/nix-src/issues/224
+            - nix-installer: DeterminateSystems/determinate-nix-action
+              os: macos-15-intel
       runs-on: ''${{ matrix.os }}
       steps:
         - name: Checkout this repo
@@ -522,6 +526,10 @@ in
           nix-installer:
             - DeterminateSystems/determinate-nix-action
             - nixbuild/nix-quick-install-action
+          exclude:
+            # See https://github.com/DeterminateSystems/nix-src/issues/224
+            - nix-installer: DeterminateSystems/determinate-nix-action
+              os: macos-15-intel
       runs-on: ''${{ matrix.os }}
       steps:
         - name: Checkout this repo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Replace all occurences of `macos-14` with `macos-15-intel`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Addresses:
- #250

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Via CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
